### PR TITLE
Enhancement: When permissions are denied initially nothing happens on mic icon click

### DIFF
--- a/app/src/main/java/by/naxa/soundrecorder/fragments/RecordFragment.java
+++ b/app/src/main/java/by/naxa/soundrecorder/fragments/RecordFragment.java
@@ -14,12 +14,14 @@ import android.os.Bundle;
 import android.os.Environment;
 import android.os.IBinder;
 import android.os.SystemClock;
+import android.provider.Settings;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Chronometer;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -236,12 +238,24 @@ public class RecordFragment extends Fragment {
                     if (PermissionsHelper.checkAndRequestPermissions(
                             RecordFragment.this, MY_PERMISSIONS_REQUEST_RECORD_AUDIO)) {
                         startRecording();
+                    } else {
+                        Toast.makeText(getActivity(), getString(R.string.error_no_permission_granted_record), Toast.LENGTH_LONG).show();
+                        openAppSettings();
                     }
                 } else {
                     stopRecording();
                 }
             }
         };
+    }
+
+    private void openAppSettings() {
+        Intent intent = new Intent(
+                Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                Uri.fromParts("package", requireActivity().getPackageName(), null)
+        );
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        startActivity(intent);
     }
 
     private Intent getStartServiceIntent() {


### PR DESCRIPTION
### Issue:
When permissions are denied initially nothing happens on mic icon click

### Expected behavior:
When permissions are denied initially Open app settings for permissions on the mic-icon click and display a toast with a relevant message.

### Description and steps:
When permissions are denied initially, the app should convey a proper message mentioning the reason for not starting the recording and redirect the user to the settings page to enable the permission
Steps:
1. Open app after installation and click on the mic-icon
2. Deny both storage and microphone access permission
3. Again click on the mic-icon, nothing happens

### Issue recording:
https://user-images.githubusercontent.com/20037228/196821370-e933ac69-733b-4c02-a325-91e3f8be6243.mp4

### Fixed issue recording:
https://user-images.githubusercontent.com/20037228/196821387-32392a19-a172-4cc7-9e2f-a9283a59b1ae.mp4



Please let me know if you have any feedback.
Thank you!