### PR TITLE
BugFix: Text-color doesn't appear as per the theme when phone is rotated to the landscape mode(Dark theme)

### DIFF
--- a/app/src/main/res/layout-land/fragment_record.xml
+++ b/app/src/main/res/layout-land/fragment_record.xml
@@ -86,7 +86,6 @@
         android:layout_marginBottom="16dp"
         android:fontFamily="sans-serif-condensed"
         android:text="@string/record_prompt"
-        android:textColor="@color/primary_text"
         android:textSize="17sp"
         android:textStyle="bold" />
 


### PR DESCRIPTION
## Issue:
Text color doesn't appear as per the theme when the phone is rotated to landscape mode. "Tap the button to start recording" and "Recording..." texts appear in black color when phone rotated to landscape mode in the dark theme

## Expected behavior:
These two texts should appear in the white shade in the dark mode. But currently they are getting displayed in the black color only in the landscape mode

## Steps:
1. Open the app and set it to the dark mode
2. Rotate the device and check the text colors

## Issue recording:
https://user-images.githubusercontent.com/20037228/196822546-5dd3b10a-7488-4afb-8008-2614f61b72dc.mp4

## Fixed issue screenshots:
![TextColor1](https://user-images.githubusercontent.com/20037228/196822890-c87606e5-e1ae-434a-870d-1699dc5f45b8.png)
![TextColor2](https://user-images.githubusercontent.com/20037228/196822896-82ea89ba-8aba-4c13-bdd1-dd825c99b7a0.png)

Please let me know if you have any feedback.
Thank you!